### PR TITLE
return early when processing data/absolute/hash urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ function processCopy(result, urlMeta, opts, decl, oldValue) {
         urlMeta.value.indexOf('#') === 0 ||
         /^[a-z]+:\/\//.test(urlMeta.value)
     ) {
-        updateUrl(decl, oldValue, urlMeta);
+        return updateUrl(decl, oldValue, urlMeta);
     }
 
     /**


### PR DESCRIPTION
Currently the `updateUrl` gets called but goes on to try and process these urls just like any other, usually failing.
