### PR TITLE
Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "eslint src/** && babel-tape-runner \"src/tests/index.js\" | tap-spec",
+    "test": "eslint src && babel-tape-runner \"src/tests/index.js\" | tap-spec",
     "clean": "rm -rf dist",
     "build": "npm run clean && babel src --source-maps --out-dir dist --ignore /tests/ --presets es2015",
     "start": "babel src --watch --source-maps --out-dir dist --ignore /tests/",

--- a/src/index.js
+++ b/src/index.js
@@ -199,11 +199,10 @@ function getFileMeta(dirname, value, opts) {
                 // the absolute path without the #hash param
                 fileMeta.absolutePath = pathName;
 
-                fileMeta.path = fileMeta
-                    .absolutePath
-                    .replace(fileMeta.src, '')
-                    .replace(fileMeta.fullName, '')
-                    .replace(/^\/+|\/+$/gm, '');
+                fileMeta.path = path.relative(
+                    fileMeta.src,
+                    path.dirname(pathName)
+                );
 
                 fileMeta.extra = extra;
 
@@ -295,7 +294,7 @@ function processCopy(result, urlMeta, opts, decl, oldValue) {
             const resultUrl = path.relative(
                 relativePath,
                 fileMeta.resultAbsolutePath
-            ) + fileMeta.extra;
+            ).split('\\').join('/') + fileMeta.extra;
             return updateUrl(decl, oldValue, urlMeta, resultUrl);
         })
         .catch((err) => {
@@ -341,7 +340,10 @@ function init(userOpts = {}) {
     const opts = Object.assign({
         template: 'assets/[hash].[ext]',
         relativePath(dirname, fileMeta, result, options) {
-            return dirname.replace(fileMeta.src, options.dest);
+            return path.join(
+                options.dest,
+                path.relative(fileMeta.src, dirname)
+            );
         },
         hashFunction(contents) {
             return crypto.createHash('sha1')


### PR DESCRIPTION
Just fixed the worst parts of your code. Never use regexp for paths please. It sucks on windows. Path module do a lot good work and it's readable. Add appveyor CI. It's really hell.. was before my changes. Now there are only 10 fails. Because of hash of svg contents (windows f***ing linebreaks, sorry). I suggest you to remove svg from common-tests.json. There are still eot with `#`. If `transform` would be before hash we could fix tests, but now it's mission impossible.

`src/**` covers even css and json.

Don't do release yet please. Let's fix all possible problems.
