### PR TITLE
CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-sudo: false
 language: node_js
 node_js:
-  - iojs
+  - "5"
+  - "4"
   - "0.12"
-  - "4.2"
-  - stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+    - nodejs_version: "5"
+    - nodejs_version: "4"
+    - nodejs_version: "0.12"
+
+version: "{build}"
+build: off
+deploy: off
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test


### PR DESCRIPTION
iojs doesn't matter
stable keyword is deprecated
sudo is not required because since january 2015 travis uses containers.
`4` covers the latest minor
Appveyor config from postcss repo, just enable it

After this I'll commit something it that pr
