### PR TITLE
Upgrade es2015 build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "eslint-config-tinchoz49"
-}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/index.js').default;

--- a/package.json
+++ b/package.json
@@ -2,30 +2,31 @@
   "name": "postcss-copy",
   "version": "3.0.0",
   "description": "A postcss plugin to copy all assets referenced in CSS to a custom destination folder and updating the URLs.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "dependencies": {
     "escape-string-regexp": "^1.0.4",
     "minimatch": "^3.0.0",
-    "mkdirp": "~0.5.1",
-    "path-exists": "~2.0.0",
-    "postcss": "~5.0.10",
-    "reduce-function-call": "~1.0.1"
+    "mkdirp": "^0.5.1",
+    "path-exists": "^2.1.0",
+    "postcss": "^5.0.10",
+    "reduce-function-call": "^1.0.1"
   },
   "devDependencies": {
-    "babel-cli": "~6.1.2",
-    "babel-core": "~5.8.33",
+    "babel-cli": "^6.5.1",
     "babel-eslint": "~4.1.4",
-    "babel-preset-es2015": "~6.1.2",
-    "babel-tape-runner": "~1.3.0",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-transform-object-assign": "^6.5.0",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-tape-runner": "^2.0.0",
     "conventional-changelog": "^0.5.1",
     "del": "^2.2.0",
     "eslint": "~1.8.0",
     "eslint-config-airbnb": "~0.1.0",
     "eslint-config-tinchoz49": "~1.0.3",
     "eslint-plugin-react": "~3.7.1",
-    "imagemin": "~4.0.0",
-    "tap-spec": "~4.1.0",
-    "tape": "~4.2.2"
+    "imagemin": "^4.0.0",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.4.0"
   },
   "files": [
     "dist"
@@ -34,11 +35,22 @@
     "test": "babel-tape-runner \"src/tests/index.js\" | tap-spec",
     "posttest": "eslint src",
     "clean": "rm -rf dist",
-    "build": "npm run clean && babel src --source-maps --out-dir dist --ignore /tests/ --presets es2015",
+    "build": "npm run clean && babel src --source-maps --out-dir dist --ignore /tests/",
     "start": "babel src --watch --source-maps --out-dir dist --ignore /tests/",
     "prepublish": "npm run test && npm run build",
-    "version": "conventional-changelog -i CHANGELOG.md --overwrite && git add CHANGELOG.md",
-    "debug": "iron-node tests/index.js"
+    "version": "conventional-changelog -i CHANGELOG.md --overwrite && git add CHANGELOG.md"
+  },
+  "eslintConfig": {
+    "extends": "tinchoz49"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ],
+    "plugins": [
+      "transform-object-assign",
+      "add-module-exports"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You don't need afraid minors if you use normal packages which follows semver.
Why do you need source maps?
