### PR TITLE
Simplify default template

### DIFF
--- a/src/__tests__/common-tests.json
+++ b/src/__tests__/common-tests.json
@@ -152,106 +152,106 @@
     "no-modified": "images/test.jpg"
   }
 },{
-  "name": "process test => template: 'assets/[hash].[ext]', relativePath from the to option",
+  "name": "process test => template: '[hash].[ext]', relativePath from the to option",
   "opts": {
     "relativePath": false
   },
   "assertions": {
     "index": [{
       "desc": "@index.css => process url image (simple)",
-      "match": "assets/b6c8f21e92b50900.jpg"
+      "match": "b6c8f21e92b50900.jpg"
     }, {
       "desc": "@index.css => process url image (with parameters)",
-      "match": "assets/0ed7c955a2951f04.jpg?#iefix&v=4.4.0"
+      "match": "0ed7c955a2951f04.jpg?#iefix&v=4.4.0"
     }, {
       "desc": "@index.css => extra rules in image (simple)",
-      "match": "url('assets/b6c8f21e92b50900.jpg') center center",
+      "match": "url('b6c8f21e92b50900.jpg') center center",
       "regex-simple": true
     }],
     "component": [{
       "desc": "@component/index.css => process url image (simple)",
-      "match": "assets/27da26a06634b050.jpg"
+      "match": "27da26a06634b050.jpg"
     }, {
       "desc": "@component/index.css => process url image (with parameters)",
-      "match": "assets/0ed7c955a2951f04.jpg?#iefix&v=4.4.0"
+      "match": "0ed7c955a2951f04.jpg?#iefix&v=4.4.0"
     }],
     "external_libs": [{
       "desc": "@external_libs/bootstrap.css => process url fonts ttf",
-      "match": "assets/44bc1850f5709722.ttf"
+      "match": "44bc1850f5709722.ttf"
     }, {
       "desc": "@external_libs/bootstrap.css => process url fonts eot",
-      "match": "assets/86b6f62b7853e67d.eot"
+      "match": "86b6f62b7853e67d.eot"
     }, {
       "desc": "@external_libs/bootstrap.css => process url fonts eot?#iefix",
-      "match": "assets/86b6f62b7853e67d.eot?#iefix"
+      "match": "86b6f62b7853e67d.eot?#iefix"
     }, {
       "desc": "@external_libs/bootstrap.css => process url fonts woff",
-      "match": "assets/278e49a86e634da6.woff"
+      "match": "278e49a86e634da6.woff"
     }, {
       "desc": "@external_libs/bootstrap.css => process url fonts woff2",
-      "match": "assets/ca35b697d99cae4d.woff2"
+      "match": "ca35b697d99cae4d.woff2"
     }],
     "exists": [
-      "assets/b6c8f21e92b50900.jpg",
-      "assets/0ed7c955a2951f04.jpg",
-      "assets/27da26a06634b050.jpg",
-      "assets/44bc1850f5709722.ttf",
-      "assets/86b6f62b7853e67d.eot",
-      "assets/278e49a86e634da6.woff",
-      "assets/ca35b697d99cae4d.woff2"
+      "b6c8f21e92b50900.jpg",
+      "0ed7c955a2951f04.jpg",
+      "27da26a06634b050.jpg",
+      "44bc1850f5709722.ttf",
+      "86b6f62b7853e67d.eot",
+      "278e49a86e634da6.woff",
+      "ca35b697d99cae4d.woff2"
     ],
-    "no-modified": "assets/0ed7c955a2951f04.jpg"
+    "no-modified": "0ed7c955a2951f04.jpg"
   }
 },{
-  "name": "process test => template: 'assets/[hash].[ext]', hashFunction: {custom}",
+  "name": "process test => template: '[hash].[ext]', hashFunction: {custom}",
   "opts": {
     "hashFunction": "custom"
   },
   "assertions": {
     "index": [{
       "desc": "@index.css => process url image (simple)",
-      "match": "assets/tsjyHpK1CQAzLrWA3hok0f01nks.jpg"
+      "match": "tsjyHpK1CQAzLrWA3hok0f01nks.jpg"
     }, {
       "desc": "@index.css => process url image (with parameters)",
-      "match": "assets/DtfJVaKVHwRz_PkVXOweAq13S0o.jpg?#iefix&v=4.4.0"
+      "match": "DtfJVaKVHwRz_PkVXOweAq13S0o.jpg?#iefix&v=4.4.0"
     }, {
       "desc": "@index.css => extra rules in image (simple)",
-      "match": "url('assets/tsjyHpK1CQAzLrWA3hok0f01nks.jpg') center center",
+      "match": "url('tsjyHpK1CQAzLrWA3hok0f01nks.jpg') center center",
       "regex-simple": true
     }],
     "component": [{
       "desc": "@component/index.css => process url image (simple)",
-      "match": "../assets/J9omoGY0sFB4U5nyxLRB6t3Ms7w.jpg"
+      "match": "../J9omoGY0sFB4U5nyxLRB6t3Ms7w.jpg"
     }, {
       "desc": "@component/index.css => process url image (with parameters)",
-      "match": "../assets/DtfJVaKVHwRz_PkVXOweAq13S0o.jpg?#iefix&v=4.4.0"
+      "match": "../DtfJVaKVHwRz_PkVXOweAq13S0o.jpg?#iefix&v=4.4.0"
     }],
     "external_libs": [{
       "desc": "@external_libs/bootstrap.css => process url fonts ttf",
-      "match": "../../assets/RLwYUPVwlyJnsWmuGPHLBrYR_6I.ttf"
+      "match": "../../RLwYUPVwlyJnsWmuGPHLBrYR_6I.ttf"
     }, {
       "desc": "@external_libs/bootstrap.css => process url fonts eot",
-      "match": "../../assets/hrb2K3hT5n0-Y19lEqWl78WOo8M.eot"
+      "match": "../../hrb2K3hT5n0-Y19lEqWl78WOo8M.eot"
     }, {
       "desc": "@external_libs/bootstrap.css => process url fonts eot?#iefix",
-      "match": "../../assets/hrb2K3hT5n0-Y19lEqWl78WOo8M.eot?#iefix"
+      "match": "../../hrb2K3hT5n0-Y19lEqWl78WOo8M.eot?#iefix"
     }, {
       "desc": "@external_libs/bootstrap.css => process url fonts woff",
-      "match": "../../assets/J45JqG5jTabyoC87R92dKo8mIQ8.woff"
+      "match": "../../J45JqG5jTabyoC87R92dKo8mIQ8.woff"
     }, {
       "desc": "@external_libs/bootstrap.css => process url fonts woff2",
-      "match": "../../assets/yjW2l9mcrk0bYPLWD803dxmH6wc.woff2"
+      "match": "../../yjW2l9mcrk0bYPLWD803dxmH6wc.woff2"
     }],
     "exists": [
-      "assets/tsjyHpK1CQAzLrWA3hok0f01nks.jpg",
-      "assets/DtfJVaKVHwRz_PkVXOweAq13S0o.jpg",
-      "assets/J9omoGY0sFB4U5nyxLRB6t3Ms7w.jpg",
-      "assets/RLwYUPVwlyJnsWmuGPHLBrYR_6I.ttf",
-      "assets/hrb2K3hT5n0-Y19lEqWl78WOo8M.eot",
-      "assets/J45JqG5jTabyoC87R92dKo8mIQ8.woff",
-      "assets/yjW2l9mcrk0bYPLWD803dxmH6wc.woff2"
+      "tsjyHpK1CQAzLrWA3hok0f01nks.jpg",
+      "DtfJVaKVHwRz_PkVXOweAq13S0o.jpg",
+      "J9omoGY0sFB4U5nyxLRB6t3Ms7w.jpg",
+      "RLwYUPVwlyJnsWmuGPHLBrYR_6I.ttf",
+      "hrb2K3hT5n0-Y19lEqWl78WOo8M.eot",
+      "J45JqG5jTabyoC87R92dKo8mIQ8.woff",
+      "yjW2l9mcrk0bYPLWD803dxmH6wc.woff2"
     ],
-    "no-modified": "assets/DtfJVaKVHwRz_PkVXOweAq13S0o.jpg"
+    "no-modified": "DtfJVaKVHwRz_PkVXOweAq13S0o.jpg"
   }
 }, {
   "name": "process test => template: 'assets/[hash].[ext]', inputPath: {custom}",

--- a/src/__tests__/template.js
+++ b/src/__tests__/template.js
@@ -16,11 +16,11 @@ test('should rename files via default template', t => {
 
         t.is(result.warnings().length, 0);
 
-        t.regex(css, makeRegex('assets/0ed7c955a2951f04.jpg?#iefix&v=4.4.0'));
-        t.ok(exists(join(tempFolder, 'assets/0ed7c955a2951f04.jpg')));
+        t.regex(css, makeRegex('0ed7c955a2951f04.jpg?#iefix&v=4.4.0'));
+        t.ok(exists(join(tempFolder, '0ed7c955a2951f04.jpg')));
 
-        t.regex(css, makeRegex('assets/b6c8f21e92b50900.jpg'));
-        t.ok(exists(join(tempFolder, 'assets/b6c8f21e92b50900.jpg')));
+        t.regex(css, makeRegex('b6c8f21e92b50900.jpg'));
+        t.ok(exists(join(tempFolder, 'b6c8f21e92b50900.jpg')));
     });
 });
 

--- a/src/__tests__/validate-url.js
+++ b/src/__tests__/validate-url.js
@@ -25,7 +25,7 @@ test('should ignore if the url() is not valid', t => {
     .then(result => {
         const css = result.css;
         t.is(result.warnings().length, 0);
-        t.regex(css, makeRegex('assets/b6c8f21e92b50900.jpg'));
+        t.regex(css, makeRegex('b6c8f21e92b50900.jpg'));
         t.regex(css, makeRegex('data:image/gif;base64,R0lGOD'));
     });
 });
@@ -42,7 +42,7 @@ test('should ignore if the asset is not found in the src path', t => {
         t.is(warnings[0].text, `Can't read the file in ${
             path.resolve('src/images/image-not-found.jpg')
         }`);
-        t.regex(css, makeRegex('assets/b6c8f21e92b50900.jpg'));
+        t.regex(css, makeRegex('b6c8f21e92b50900.jpg'));
         t.regex(css, makeRegex('images/image-not-found.jpg'));
     });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,7 @@ function processDecl(result, decl, opts) {
  */
 function init(userOpts = {}) {
     const opts = Object.assign({
-        template: 'assets/[hash].[ext]',
+        template: '[hash].[ext]',
         relativePath(dirname, fileMeta, result, options) {
             return path.join(
                 options.dest,


### PR DESCRIPTION
It's time for breaking changes. I think we should specify more simple path by default. Hash is the best case for this. `assets` is something not common. Assets path can be passed in `dest`.
